### PR TITLE
Bump `omniauth-oauth2` version

### DIFF
--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '< 2.0'
+  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
 end

--- a/omniauth-clever.gemspec
+++ b/omniauth-clever.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '<= 1.5'
+  gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.1', '< 2.0'
 end


### PR DESCRIPTION
https://zearn.kanbanize.com/ctrl_board/51/cards/5566/details/

Bump the highest allowed `omniauth-oauth2` version from `<= 1.5` to `< 2.0` to resolve [a dependabot issue](https://github.com/zearn/Dent/security/dependabot/126) we're having in our main repo.